### PR TITLE
redirect configation for /docs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -59,6 +59,7 @@ const config: Config = {
           if (existingPath.includes(`/docs/${currentVersion}`)) {
             return [
               existingPath.replace(`/docs/${currentVersion}`, '/docs/latest'),
+              existingPath.replace(`/docs/${currentVersion}`, '/docs/'),
             ];
           }
           return undefined;


### PR DESCRIPTION
when type `https://gravitino.apache.org/docs/`
will redirect to `https://gravitino.apache.org/docs/0.6.0-incubating/`