### PR TITLE
Update installation.md

### DIFF
--- a/docs/trino-connector/installation.md
+++ b/docs/trino-connector/installation.md
@@ -135,7 +135,7 @@ system
 
 You can see the `gravitino` catalog in the result set. This signifies the successful installation of the Gravitino Trino connector.
 
-Assuming you have created a catalog named `test.jdbc-mysql` in the Gravitino server, or please refer to [Create a Catalog](../manage-relational-metadata-using-gravitino.md#create-a-catalog). Then you can use the Trino CLI to connect to the Trino container and run a query like this.
+Assuming you have created a catalog named `test.jdbc_mysql` in the Gravitino server, or please refer to [Create a Catalog](../manage-relational-metadata-using-gravitino.md#create-a-catalog). Then you can use the Trino CLI to connect to the Trino container and run a query like this.
 
 ```text
 docker exec -it trino-gravitino trino
@@ -148,7 +148,7 @@ memory
 tpcds
 tpch
 system
-jdbc-mysql
+jdbc_mysql
 ```
 
-The catalog named 'jdbc-mysql' is the catalog that you created by gravitino server, and you can use it to access the mysql database like other Trino catalogs.
+The catalog named 'jdbc_mysql' is the catalog that you created by gravitino server, and you can use it to access the mysql database like other Trino catalogs.


### PR DESCRIPTION
When I was configuring according to the Trino connector-installation document, an error occurred:
`Query 20250617_091322_00020_cw43e failed: line 1:20: mismatched input '-'. Expecting: 'USING'`

I'm not sure if the creation was really successful in the document, but I found that Trino does not support creating Catalog names with a '-', so I need to change it to '_'.

Trino version：**439**


**Complete error report:**
```
2025-06-17T07:34:10.232Z        INFO    gravitino-connector-schedule-0  stdout  2025-06-17 07:34:10 ERROR CatalogConnectorManager:202 - Failed to load metalake test's catalog jdbc-mysql.
io.trino.spi.TrinoException: Failed to create internal catalog connector. The catalog is: org.apache.gravitino.trino.connector.metadata.GravitinoCatalog@2f791125
        at org.apache.gravitino.trino.connector.catalog.CatalogConnectorManager.loadCatalogImpl(CatalogConnectorManager.java:234) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogConnectorManager.loadCatalog(CatalogConnectorManager.java:223) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogConnectorManager.lambda$loadCatalogs$2(CatalogConnectorManager.java:198) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024) ~[?:?]
        at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762) ~[?:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogConnectorManager.loadCatalogs(CatalogConnectorManager.java:188) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogConnectorManager.loadMetalake(CatalogConnectorManager.java:131) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[?:?]
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: io.trino.spi.TrinoException: Failed to register catalog jdbc-mysql
        at org.apache.gravitino.trino.connector.catalog.CatalogRegister.registerCatalog(CatalogRegister.java:186) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogConnectorManager.loadCatalogImpl(CatalogConnectorManager.java:229) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        ... 12 more
Caused by: io.trino.spi.TrinoException: Failed to execute query: CREATE CATALOG jdbc-mysql USING gravitino WITH ( "__gravitino.dynamic.connector" = 'true', "__gravitino.dynamic.connector.catalog.config" = '{"metalake":"test","provider":"jdbc-mysql","name":"jdbc-mysql","properties":{"jdbc-url":"jdbc:mysql://mysql8:3306","jdbc-user":"root","jdbc-driver":"com.mysql.cj.jdbc.Driver","jdbc-password":"xxxxxxxx.","in-use":"true"},"lastModifiedTime":1750145444767}', "gravitino.uri"='http://gravitino:8090',"gravitino.metalake"='test')
        at org.apache.gravitino.trino.connector.catalog.CatalogRegister.executeSql(CatalogRegister.java:240) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogRegister.registerCatalog(CatalogRegister.java:181) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogConnectorManager.loadCatalogImpl(CatalogConnectorManager.java:229) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        ... 12 more
Caused by: java.sql.SQLException: Query failed (#20250617_073405_00022_b6jdr): line 1:20: mismatched input '-'. Expecting: 'USING'
        at io.trino.jdbc.AbstractTrinoResultSet.resultsException(AbstractTrinoResultSet.java:1937) ~[trino-jdbc-435.jar:435]
        at io.trino.jdbc.TrinoResultSet.getColumns(TrinoResultSet.java:318) ~[trino-jdbc-435.jar:435]
        at io.trino.jdbc.TrinoResultSet.create(TrinoResultSet.java:61) ~[trino-jdbc-435.jar:435]
        at io.trino.jdbc.TrinoStatement.internalExecute(TrinoStatement.java:262) ~[trino-jdbc-435.jar:435]
        at io.trino.jdbc.TrinoStatement.execute(TrinoStatement.java:240) ~[trino-jdbc-435.jar:435]
        at org.apache.gravitino.trino.connector.catalog.CatalogRegister.executeSql(CatalogRegister.java:230) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogRegister.registerCatalog(CatalogRegister.java:181) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        at org.apache.gravitino.trino.connector.catalog.CatalogConnectorManager.loadCatalogImpl(CatalogConnectorManager.java:229) ~[gravitino-trino-connector-0.9.0-incubating.jar:?]
        ... 12 more
Caused by: io.trino.jdbc.$internal.client.FailureInfo$FailureException: line 1:20: mismatched input '-'. Expecting: 'USING'
        at io.trino.sql.parser.ErrorHandler.syntaxError(ErrorHandler.java:108) ~[trino-parser-439.jar:439]
        at org.antlr.v4.runtime.ProxyErrorListener.syntaxError(ProxyErrorListener.java:41) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at org.antlr.v4.runtime.Parser.notifyErrorListeners(Parser.java:544) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at org.antlr.v4.runtime.DefaultErrorStrategy.reportInputMismatch(DefaultErrorStrategy.java:327) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at org.antlr.v4.runtime.DefaultErrorStrategy.reportError(DefaultErrorStrategy.java:139) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at io.trino.grammar.sql.SqlBaseParser.statement(SqlBaseParser.java:5772) ~[trino-grammar-439.jar:439]
        at io.trino.grammar.sql.SqlBaseParser.singleStatement(SqlBaseParser.java:345) ~[trino-grammar-439.jar:439]
        at io.trino.sql.parser.SqlParser.invokeParser(SqlParser.java:172) ~[trino-parser-439.jar:439]
        at io.trino.sql.parser.SqlParser.invokeParser(SqlParser.java:125) ~[trino-parser-439.jar:439]
        at io.trino.sql.parser.SqlParser.createStatement(SqlParser.java:90) ~[trino-parser-439.jar:439]
        at io.trino.execution.QueryPreparer.prepareQuery(QueryPreparer.java:54) ~[trino-main-439.jar:439]
        at io.trino.dispatcher.DispatchManager.createQueryInternal(DispatchManager.java:196) ~[trino-main-439.jar:439]
        at io.trino.dispatcher.DispatchManager.lambda$createQuery$0(DispatchManager.java:165) ~[trino-main-439.jar:439]
        at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:212) ~[opentelemetry-context-1.34.1.jar:1.34.1]
        at io.trino.$gen.Trino_439____20250617_073159_2.run(Unknown Source) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: io.trino.jdbc.$internal.client.FailureInfo$FailureException
        at io.trino.sql.parser.SqlParser$2.recoverInline(SqlParser.java:145) ~[trino-parser-439.jar:439]
        at org.antlr.v4.runtime.Parser.match(Parser.java:208) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at io.trino.grammar.sql.SqlBaseParser.statement(SqlBaseParser.java:3036) ~[trino-grammar-439.jar:439]
        at io.trino.grammar.sql.SqlBaseParser.singleStatement(SqlBaseParser.java:345) ~[trino-grammar-439.jar:439]
        at io.trino.sql.parser.SqlParser.invokeParser(SqlParser.java:172) ~[trino-parser-439.jar:439]
        at io.trino.sql.parser.SqlParser.invokeParser(SqlParser.java:125) ~[trino-parser-439.jar:439]
        at io.trino.sql.parser.SqlParser.createStatement(SqlParser.java:90) ~[trino-parser-439.jar:439]
        at io.trino.execution.QueryPreparer.prepareQuery(QueryPreparer.java:54) ~[trino-main-439.jar:439]
        at io.trino.dispatcher.DispatchManager.createQueryInternal(DispatchManager.java:196) ~[trino-main-439.jar:439]
        at io.trino.dispatcher.DispatchManager.lambda$createQuery$0(DispatchManager.java:165) ~[trino-main-439.jar:439]
        at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:212) ~[opentelemetry-context-1.34.1.jar:1.34.1]
        at io.trino.$gen.Trino_439____20250617_073159_2.run(Unknown Source) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```
