### PR TITLE
Update authorization-pushdown.md

### DIFF
--- a/docs/security/authorization-pushdown.md
+++ b/docs/security/authorization-pushdown.md
@@ -98,12 +98,14 @@ The Apache Hive service will use HDFS to store its data. You have created a `hdf
 ```properties
 authorization-provider=chain
 authorization.chain.plugins=hive,hdfs
+authorization.chain.hive.provider=ranger
 authorization.chain.hive.ranger.admin.url=http://ranger-service:6080
 authorization.chain.hive.ranger.service.type=HadoopSQL
 authorization.chain.hive.ranger.service.name=hiveRepo
 authorization.chain.hive.ranger.auth.type=simple
 authorization.chain.hive.ranger.username=Jack
 authorization.chain.hive.ranger.password=PWD123
+authorization.chain.hdfs.provider=ranger
 authorization.chain.hdfs.ranger.admin.url=http://ranger-service:6080
 authorization.chain.hdfs.ranger.service.type=HDFS
 authorization.chain.hdfs.ranger.service.name=hdfsRepo


### PR DESCRIPTION
Caused by: java.lang.IllegalArgumentException: Missing required properties {authorization.chain.hive.ranger.admin.url=http://xxxx:6080, authorization.chain.hdfs.ranger.username=admin, authorization.chain.hive.ranger.auth.type=simple, authorization.chain.hive.ranger.username=admin, authorization.chain.hdfs.ranger.admin.url=http://xxxx:6080, authorization.chain.hdfs.ranger.auth.type=simple, authorization.chain.hive.ranger.service.name=hiveRepo, authorization.chain.hive.ranger.service.type=HadoopSQL, authorization.chain.hdfs.ranger.service.type=HDFS, authorization.chain.hive.ranger.password=xxxx, authorization.chain.hdfs.ranger.service.name=hdfsRepo, authorization.chain.hdfs.ranger.password=xxxx} for plugin: ^authorization.chain.hive.provider$
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:445) ~[guava-32.1.3-jre.jar:?]
	at org.apache.gravitino.authorization.common.ChainedAuthorizationProperties.validate(ChainedAuthorizationProperties.java:171) ~[?:?]
	at org.apache.gravitino.authorization.chain.ChainedAuthorizationPlugin.initPlugins(ChainedAuthorizationPlugin.java:57) ~[?:?]
	at org.apache.gravitino.authorization.chain.ChainedAuthorizationPlugin.<init>(ChainedAuthorizationPlugin.java:51) ~[?:?]
	at org.apache.gravitino.authorization.chain.ChainedAuthorization.newPlugin(ChainedAuthorization.java:37) ~[?:?]
	at org.apache.gravitino.connector.BaseCatalog.lambda$initAuthorizationPluginInstance$1(BaseCatalog.java:217) ~[gravitino-core-0.8.0-zdh15.7.1-SNAPSHOT.jar:?]
	at org.apache.gravitino.utils.IsolatedClassLoader.withClassLoader(IsolatedClassLoader.java:86) ~[gravitino-core-0.8.0-zdh15.7.1-SNAPSHOT.jar:?]
	at org.apache.gravitino.connector.BaseCatalog.initAuthorizationPluginInstance(BaseCatalog.java:215) ~[gravitino-core-0.8.0-zdh15.7.1-SNAPSHOT.jar:?]