### PR TITLE
Add download links for release 1.2.1

### DIFF
--- a/src/pages/downloads.mdx
+++ b/src/pages/downloads.mdx
@@ -1,5 +1,32 @@
 ## Apache Gravitino Downloads
 
+### 1.2.1
+
+[Gravitino source](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz.sha512)
+
+[Gravitino binary](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz.sha512)
+
+[Gravitino Iceberg REST server](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz.sha512)
+
+[Gravitino Lance REST server](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz.sha512)
+
+The number ranges in the Trino connector filenames indicate the compatible Trino server versions. Please download the connector that matches your Trino server version.
+
+[Gravitino Trino connector (435-439)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz.sha512)
+
+[Gravitino Trino connector (440-445)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz.sha512)
+
+[Gravitino Trino connector (446-451)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz.sha512)
+
+[Gravitino Trino connector (452-468)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz.sha512)
+
+[Gravitino Trino connector (469-472)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz.sha512)
+
+[Gravitino Trino connector (473-478)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz.sha512)
+
+The [KEYS file](https://downloads.apache.org/gravitino/KEYS) and ASC files can be used to verify the release. Please follow the instructions on the download page to verify the release before you use it.
+
+
 ### 1.2.0
 
 [Gravitino source](https://www.apache.org/dyn/closer.lua/gravitino/1.2.0/gravitino-1.2.0-src.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.0/gravitino-1.2.0-src.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.0/gravitino-1.2.0-src.tar.gz.sha512)

--- a/src/pages/downloads.mdx
+++ b/src/pages/downloads.mdx
@@ -2,27 +2,27 @@
 
 ### 1.2.1
 
-[Gravitino source](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz.sha512)
+[Gravitino source](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-src.tar.gz.sha512)
 
-[Gravitino binary](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz.sha512)
+[Gravitino binary](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-1.2.1-bin.tar.gz.sha512)
 
-[Gravitino Iceberg REST server](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz.sha512)
+[Gravitino Iceberg REST server](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-iceberg-rest-server-1.2.1-bin.tar.gz.sha512)
 
-[Gravitino Lance REST server](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz.sha512)
+[Gravitino Lance REST server](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-lance-rest-server-1.2.1-bin.tar.gz.sha512)
 
 The number ranges in the Trino connector filenames indicate the compatible Trino server versions. Please download the connector that matches your Trino server version.
 
-[Gravitino Trino connector (435-439)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz.sha512)
+[Gravitino Trino connector (435-439)](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-435-439-1.2.1.tar.gz.sha512)
 
-[Gravitino Trino connector (440-445)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz.sha512)
+[Gravitino Trino connector (440-445)](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-440-445-1.2.1.tar.gz.sha512)
 
-[Gravitino Trino connector (446-451)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz.sha512)
+[Gravitino Trino connector (446-451)](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-446-451-1.2.1.tar.gz.sha512)
 
-[Gravitino Trino connector (452-468)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz.sha512)
+[Gravitino Trino connector (452-468)](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-452-468-1.2.1.tar.gz.sha512)
 
-[Gravitino Trino connector (469-472)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz.sha512)
+[Gravitino Trino connector (469-472)](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-469-472-1.2.1.tar.gz.sha512)
 
-[Gravitino Trino connector (473-478)](https://dlcdn.apache.org/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz.sha512)
+[Gravitino Trino connector (473-478)](https://www.apache.org/dyn/closer.lua/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz) [ASC](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz.asc) [SHA](https://downloads.apache.org/gravitino/1.2.1/gravitino-trino-connector-473-478-1.2.1.tar.gz.sha512)
 
 The [KEYS file](https://downloads.apache.org/gravitino/KEYS) and ASC files can be used to verify the release. Please follow the instructions on the download page to verify the release before you use it.
 


### PR DESCRIPTION
## Summary
- Add download links for Gravitino 1.2.1 release
- Includes source, binary, Iceberg REST server, Lance REST server, and 6 Trino connector variants
- Uses dlcdn.apache.org for downloads and downloads.apache.org for ASC/SHA verification files

## Downloads Added
- gravitino-1.2.1-src.tar.gz
- gravitino-1.2.1-bin.tar.gz
- gravitino-iceberg-rest-server-1.2.1-bin.tar.gz
- gravitino-lance-rest-server-1.2.1-bin.tar.gz
- gravitino-trino-connector-435-439-1.2.1.tar.gz
- gravitino-trino-connector-440-445-1.2.1.tar.gz
- gravitino-trino-connector-446-451-1.2.1.tar.gz
- gravitino-trino-connector-452-468-1.2.1.tar.gz
- gravitino-trino-connector-469-472-1.2.1.tar.gz
- gravitino-trino-connector-473-478-1.2.1.tar.gz

All links verified and returning HTTP 200.